### PR TITLE
Potential fix for code scanning alert no. 6: Improper code sanitization

### DIFF
--- a/src/compiler/codegen.ts
+++ b/src/compiler/codegen.ts
@@ -26,6 +26,25 @@ import {
   UnaryExpression,
 } from './ast';
 
+// Escape potentially dangerous chars when embedding in JavaScript code
+const charMap: Record<string, string> = {
+  '<': '\\u003C',
+  '>': '\\u003E',
+  '/': '\\u002F',
+  '\\': '\\\\',
+  '\b': '\\b',
+  '\f': '\\f',
+  '\n': '\\n',
+  '\r': '\\r',
+  '\t': '\\t',
+  '\0': '\\0',
+  '\u2028': '\\u2028',
+  '\u2029': '\\u2029'
+};
+function escapeUnsafeChars(str: string): string {
+  return str.replace(/[<>\b\f\n\r\t\0\u2028\u2029/\\]/g, x => charMap[x] || x);
+}
+
 type BinaryExpression = import('./ast').BinaryExpression;
 type ExpressionNode = import('./ast').Expression;
 
@@ -147,7 +166,7 @@ export class CodeGenerator {
   private generateBind(statement: BindStatement): void {
     const source = this.generateExpression(statement.source);
     const selector = this.generateExpression(statement.selector);
-    const property = JSON.stringify(statement.property);
+    const property = escapeUnsafeChars(JSON.stringify(statement.property));
     this.emitLine(`sprout.bind(() => ${source}, ${selector}, ${property});`);
   }
 


### PR DESCRIPTION
Potential fix for [https://github.com/sprout-lang/Sprout/security/code-scanning/6](https://github.com/sprout-lang/Sprout/security/code-scanning/6)

The best way to fix the problem is to implement an additional escaping function that transforms potentially unsafe Unicode and HTML-related characters into their safe Unicode-escaped versions after `JSON.stringify` is called on the string. This prevents problematic substrings and characters from being directly embedded into the resulting JavaScript code, plugging any code injection risks. The fix should be applied to the region in `src/compiler/codegen.ts` where `JSON.stringify(statement.property)` is used—specifically, in the call to `sprout.bind` (lines 150-151).

To implement this, add a utility function `escapeUnsafeChars` locally within the file, closely modeled on canonical solutions (as in the background). Then wrap the output of `JSON.stringify(statement.property)` with this escape function when assigning `property` on line 150. This approach requires no external dependencies.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
